### PR TITLE
Update email.js to validate gTLDs up to 63 chars

### DIFF
--- a/validators/email.js
+++ b/validators/email.js
@@ -1,7 +1,7 @@
 ValidateForm.addValidator('data-email', function($el, instance) {
   var email = $el.val() || '';
 
-  var isValid =  !! email.trim().match(/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/ig);
+  var isValid =  !! email.trim().match(/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,63}$/ig);
 
   if (isValid) {
     instance._showSuccess();


### PR DESCRIPTION
ICANN allows registration and use of global TLDs with up to 63 ASCII characters. Previously, this validator only allowed between 2 and 4 characters, now it allows between 2 and 63.